### PR TITLE
fixed pawn capture target bug when at the edge of the board

### DIFF
--- a/chess-functional/app.js
+++ b/chess-functional/app.js
@@ -456,12 +456,24 @@ function highlightTiles(_homeTile, movement, sliding, piece){
             }
             if(boardRightEdge.includes(parseInt(_homeTile))){
                 exemption.push(...rightEdge);
+                if(piece === "P" || piece === "p"){
+                    let capture1 = (pieceMovement.indexOf(9) != -1) ? pieceMovement.indexOf(9): false;
+                    let capture2 = (pieceMovement.indexOf(-7) != -1) ? pieceMovement.indexOf(-7): false;
+                    let removeCapture = capture1 || capture2;
+                    exemption.push(removeCapture);                    
+                }
             }
             if(boardBottomEdge.includes(parseInt(_homeTile))){
                 exemption.push(...bottomEdge);
             }
             if(boardLeftEdge.includes(parseInt(_homeTile))){
                 exemption.push(...leftEdge);
+                if(piece === "P" || piece === "p"){
+                    let capture1 = (pieceMovement.indexOf(-9) != -1) ? pieceMovement.indexOf(-9): false;
+                    let capture2 = (pieceMovement.indexOf(7) != -1) ? pieceMovement.indexOf(7): false;
+                    let removeCapture = capture1 || capture2;
+                    exemption.push(removeCapture);                    
+                }
             }
         }
 


### PR DESCRIPTION
This fixes the bug shown below (please see screenshot).
![image3](https://user-images.githubusercontent.com/30313350/152266109-85b6c57d-d2b2-480d-bf77-62e096378761.PNG)
